### PR TITLE
Date and time

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "run-s build test:*",
     "test:unit": "nyc --silent ava",
     "watch": "run-s clean build:main && run-p \"build:main -- -w\" \"test:unit -- --watch\"",
+    "watch-tsc": "tsc --watch",
     "cov": "run-s build test:unit cov:html && opn coverage/index.html",
     "cov:html": "nyc report --reporter=html",
     "cov:send": "nyc report --reporteyarnr=lcov > coverage.lcov && codecov",

--- a/src/lib/dataInference.ts
+++ b/src/lib/dataInference.ts
@@ -62,9 +62,21 @@ export function detectValue(
     return 'unknown';
   }
 
+  const isDate = (value: any, parser?: ParserFunction) => {
+    if (typeof value === 'string' && isFormatDateValid(value, parser))
+      return true;
+    if (
+      value &&
+      Object.prototype.toString.call(value) === '[object Date]' &&
+      !isNaN(value)
+    )
+      return true;
+    return false;
+  };
+
   if (inferIsNumber(value)) {
     return 'continuous';
-  } else if (typeof value === 'string' && isFormatDateValid(value, parser)) {
+  } else if (isDate(value, parser)) {
     return 'date';
   } else {
     return 'categorical';

--- a/src/lib/dataInference.ts
+++ b/src/lib/dataInference.ts
@@ -78,8 +78,11 @@ export function isFormatDateValid(
 ): boolean {
   if(!inferIfStringIsNumber(value[0])) return false
 
-  // this will match yyyy-mm-dd and also yyyy-m-d
-  const regDate = /^([1-9][0-9]{3})\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])$/;
+  // this will match date (and time) formats:
+  //   date formats: YYYY-MM-DD or YYYY-M-D
+  //   time formats: HH:mm:ss
+  // separator between date and time can be ` ` or `, `
+  const regDate = /^([1-9][0-9]{3})\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])(,?[\s]([0-1][0-9]|[2][0-3]):([0-5][0-9])(:([0-5][0-9]))?)?$/;
   // TODO: add other regex to accept also other date formats
 
   const isFormatDateValid = regDate.test(value.toString());

--- a/src/lib/dataInference.ts
+++ b/src/lib/dataInference.ts
@@ -104,6 +104,7 @@ export function detectValue(
 
 function isValidDate(dateString: string, formats: string[]): boolean {
   const strictMode = true
+  // ts-ignore is necessary because of strictMode parameter: `Argument of type 'true' is not assignable to parameter of type 'string | undefined'.`
   // @ts-ignore
   return formats.some(format => dayjs(dateString, format, strictMode).isValid())
 }

--- a/src/lib/dataInference.ts
+++ b/src/lib/dataInference.ts
@@ -104,8 +104,7 @@ export function detectValue(
 
 function isValidDate(dateString: string, formats: string[]): boolean {
   const strictMode = true
-  // ts-ignore is necessary because of strictMode parameter: `Argument of type 'true' is not assignable to parameter of type 'string | undefined'.`
-  // @ts-ignore
+  // @ts-ignore: necessary because of strictMode parameter: `Argument of type 'true' is not assignable to parameter of type 'string | undefined'.`
   return formats.some(format => dayjs(dateString, format, strictMode).isValid())
 }
 

--- a/src/lib/dataInference.ts
+++ b/src/lib/dataInference.ts
@@ -104,11 +104,8 @@ export function detectValue(
 
 function isValidDate(dateString: string, formats: string[]): boolean {
   const strictMode = true
-  const results = formats.map(format => {
-    // @ts-ignore
-    return dayjs(dateString, format, strictMode).isValid()
-  })
-  return results.some(res => res === true)
+  // @ts-ignore
+  return formats.some(format => dayjs(dateString, format, strictMode).isValid())
 }
 
 export function isFormatDateValid(

--- a/src/lib/dataInference.ts
+++ b/src/lib/dataInference.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { get, isFinite, isNaN, isNull, isUndefined, keys } from 'lodash';
+import { get, isFinite, isNaN, isNull, isUndefined, keys, isDate, isString } from 'lodash';
 import {
   CategoricalDatum,
   ContinuousDatum,
@@ -93,22 +93,9 @@ export function detectValue(
   if (!value || isNull(value) || typeof value === 'boolean') {
     return 'unknown';
   }
-
-  const isDate = (value: any, parser?: ParserFunction) => {
-    if (typeof value === 'string' && isFormatDateValid(value, parser))
-      return true;
-    if (
-      value &&
-      Object.prototype.toString.call(value) === '[object Date]' &&
-      !isNaN(value)
-    )
-      return true;
-    return false;
-  };
-
   if (inferIsNumber(value)) {
     return 'continuous';
-  } else if (isDate(value, parser)) {
+  } else if (isDate(value) || (isString(value) && isFormatDateValid(value, parser))) {
     return 'date';
   } else {
     return 'categorical';

--- a/src/lib/dataInference.ts
+++ b/src/lib/dataInference.ts
@@ -21,13 +21,29 @@ export const DATE_FORMATS = [
   'YYYY-MM-D',
   'YYYY-M-DD',
   'YYYY-M-D',
+
   'YYYY-MM-DD HH:mm',
+  'YYYY-MM-DD HH:mm[Z]',
+  'YYYY-MM-DD[T]HH:mm',
+  'YYYY-MM-DD[T]HH:mm[Z]',
+  
   'YYYY-MM-DD HH:mm:ss',
+  'YYYY-MM-DD HH:mm:ss[Z]',
+  'YYYY-MM-DD[T]HH:mm:ss',
+  'YYYY-MM-DD[T]HH:mm:ss[Z]',
+
   'YYYY-MM-DD HH:mm:ss.SSS',
+  'YYYY-MM-DD HH:mm:ss.SSS[Z]',
+  'YYYY-MM-DD[T]HH:mm:ss.SSS',
+  'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]', // ISO8601
+
   'YYYY-MM-DD HH:mm:ss A',
   'YYYY-MM-DD HH:mm:ss a',
-  'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]' // ISO8601
-]
+  
+  // these two formats don't work
+  // 'YYYY-MM-DD HH:mm:ssZ', // 2013-02-08 09:00:00+07:00
+  // 'YYYY-MM-DD HH:mm:ssZZ', // 2013-02-08 09:00:00-0700
+];
 
 export type GenericDatumValue = number | string | boolean | null;
 
@@ -99,7 +115,8 @@ export function detectValue(
   }
 }
 
-function isValidDate(dateString: string, formats: string[], strictMode = true): boolean {
+function isValidDate(dateString: string, formats: string[]): boolean {
+  const strictMode = true
   const results = formats.map(format => {
     // @ts-ignore
     return dayjs(dateString, format, strictMode).isValid()

--- a/src/lib/dataInference.ts
+++ b/src/lib/dataInference.ts
@@ -13,6 +13,22 @@ import { getAllKeys } from './stats';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 dayjs.extend(customParseFormat);
 
+// references:
+// https://day.js.org/docs/en/parse/string-format
+// https://day.js.org/docs/en/display/format
+export const DATE_FORMATS = [
+  'YYYY-MM-DD',
+  'YYYY-MM-D',
+  'YYYY-M-DD',
+  'YYYY-M-D',
+  'YYYY-MM-DD HH:mm',
+  'YYYY-MM-DD HH:mm:ss',
+  'YYYY-MM-DD HH:mm:ss.SSS',
+  'YYYY-MM-DD HH:mm:ss A',
+  'YYYY-MM-DD HH:mm:ss a',
+  'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]' // ISO8601
+]
+
 export type GenericDatumValue = number | string | boolean | null;
 
 export type GenericDatum<T extends StringKeyedObj> = {
@@ -82,22 +98,6 @@ export function detectValue(
     return 'categorical';
   }
 }
-
-// references:
-// https://day.js.org/docs/en/parse/string-format
-// https://day.js.org/docs/en/display/format
-export const DATE_FORMATS = [
-  'YYYY-MM-DD',
-  'YYYY-MM-D',
-  'YYYY-M-DD',
-  'YYYY-M-D',
-  'YYYY-MM-DD HH:mm',
-  'YYYY-MM-DD HH:mm:ss',
-  'YYYY-MM-DD HH:mm:ss.SSS',
-  'YYYY-MM-DD HH:mm:ss A',
-  'YYYY-MM-DD HH:mm:ss a',
-  'YYYY-MM-DD[T]HH:mm:ss.SSS[Z]' // ISO8601
-]
 
 function isValidDate(dateString: string, formats: string[], strictMode = true): boolean {
   const results = formats.map(format => {

--- a/src/lib/dataInference.ts
+++ b/src/lib/dataInference.ts
@@ -81,8 +81,8 @@ export function isFormatDateValid(
   // this will match date (and time) formats:
   //   date formats: YYYY-MM-DD or YYYY-M-D
   //   time formats: HH:mm:ss
-  // separator between date and time can be ` ` or `, `
-  const regDate = /^([1-9][0-9]{3})\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])(,?[\s]([0-1][0-9]|[2][0-3]):([0-5][0-9])(:([0-5][0-9]))?)?$/;
+  // separator between date and time must be ` `
+  const regDate = /^([1-9][0-9]{3})\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])([\s]([0-1][0-9]|[2][0-3]):([0-5][0-9])(:([0-5][0-9]))?)?$/;
   // TODO: add other regex to accept also other date formats
 
   const isFormatDateValid = regDate.test(value.toString());

--- a/src/lib/test/dataInference.spec.ts
+++ b/src/lib/test/dataInference.spec.ts
@@ -76,16 +76,14 @@ test('isDateValid', t => {
   t.is(isFormatDateValid('2017-02-30'), true); // this day doesn't exist but we check only the date format
   t.is(isFormatDateValid('2020-04-31'), true); // this day doesn't exist but we check only the date format
   t.is(isFormatDateValid('2019-01-15 13:12:29'), true);
-  t.is(isFormatDateValid('2019-01-15, 13:12:29'), true);
-  t.is(isFormatDateValid('2019-01-15, 00:00:00'), true);
-  t.is(isFormatDateValid('2019-01-15, 23:59:59'), true);
   t.is(isFormatDateValid('17-02-2019', rightParser), true);
   t.is(isFormatDateValid('17-02-2019', wrongParser), true); // this shouldn't be right but we assume that if the user has written a parser, then the dates are in the correct format
   t.is(isFormatDateValid('17-02-2019', defaultParser), true); // this shouldn't be right but we assume that if the user has written a parser, then the dates are in the correct format
   
-  t.is(isFormatDateValid('2019-01-15, 24:00:00'), false);
-  t.is(isFormatDateValid('2019-01-15, 23:60:00'), false);
-  t.is(isFormatDateValid('2019-01-15, 23:59:60'), false);
+  t.is(isFormatDateValid('2019-01-15 13:12:29'), true);
+  t.is(isFormatDateValid('2019-01-15 24:00:00'), false);
+  t.is(isFormatDateValid('2019-01-15 23:60:00'), false);
+  t.is(isFormatDateValid('2019-01-15 23:59:60'), false);
   t.is(isFormatDateValid('2019-01-15 13:12:29.0'), false);
   t.is(isFormatDateValid('17-02-2019'), false);
   t.is(isFormatDateValid('0000-01-01'), false);

--- a/src/lib/test/dataInference.spec.ts
+++ b/src/lib/test/dataInference.spec.ts
@@ -69,28 +69,43 @@ test('isDateValid', t => {
   const defaultParser = (d: string) => dayjs(d, 'YYYY-MM-DD').unix();
 
   t.is(isFormatDateValid('1900-10-23'), true);
-  t.is(isFormatDateValid('2002-5-5'), true);
-  t.is(isFormatDateValid('1600-12-25'), true);
   t.is(isFormatDateValid('1942-11-1'), true);
-  t.is(isFormatDateValid('2000-10-10'), true);
+  t.is(isFormatDateValid('2002-5-15'), true);
+  t.is(isFormatDateValid('2000-01-10'), true);
+
+  t.is(isFormatDateValid('2020-05-01 09:35'), true);
+  t.is(isFormatDateValid('2020-05-01 09:35Z'), true);
+  t.is(isFormatDateValid('2020-05-01T09:35'), true);
+  t.is(isFormatDateValid('2020-05-01T09:35Z'), true);
+
+  t.is(isFormatDateValid('2020-05-01 09:35:20'), true);
   t.is(isFormatDateValid('2019-01-15 13:12:29'), true);
-  t.is(isFormatDateValid(new Date().toISOString()), true);
+  t.is(isFormatDateValid('2020-05-01 09:35:20Z'), true);
+  t.is(isFormatDateValid('2020-05-01T09:35:20'), true);
+  t.is(isFormatDateValid('2020-05-01T09:35:20Z'), true);
+
+  t.is(isFormatDateValid('2020-05-01 09:35:20.000'), true);
+  t.is(isFormatDateValid('2020-05-01 09:35:20.000Z'), true);
+  t.is(isFormatDateValid('2020-05-01T09:35:20.000'), true);
+  t.is(isFormatDateValid('2020-05-01T09:35:20.000Z'), true);
   t.is(isFormatDateValid('2020-05-13T08:24:45.701Z'), true);
-  t.is(isFormatDateValid('2020-05-01'), true);
-  t.is(isFormatDateValid('2020-05-1'), true);
-  t.is(isFormatDateValid('2020-5-01'), true);
-  t.is(isFormatDateValid('2020-5-1'), true);
-  t.is(isFormatDateValid('2020-05-01 00:00'), true);
-  t.is(isFormatDateValid('2020-05-01 00:00:00'), true);
-  t.is(isFormatDateValid('2020-05-01 00:00:00.101'), true);
+  t.is(isFormatDateValid(new Date().toISOString()), true);
+
   t.is(isFormatDateValid('2016-01-01 11:31:23 AM'), true);
   t.is(isFormatDateValid('2016-01-01 11:31:23 am'), true);
   t.is(isFormatDateValid('2016-01-01 23:31:23 pm'), true);
+
+
   t.is(isFormatDateValid('17-02-2019', rightParser), true);
   t.is(isFormatDateValid('17-02-2019', wrongParser), true); // this shouldn't be right but we assume that if the user has written a parser, then the dates are in the correct format
   t.is(isFormatDateValid('17-02-2019', defaultParser), true); // this shouldn't be right but we assume that if the user has written a parser, then the dates are in the correct format
-  t.is(isFormatDateValid('2019-01-15 13:12:29'), true);
-  
+
+  // t.is(isFormatDateValid('2013-02-08 09:00:00+01:00'), true);
+  // t.is(isFormatDateValid('2013-02-08 09:00:00+01:30'), true);
+  // t.is(isFormatDateValid('2013-02-08 09:00:00+0100'), true);
+  // t.is(isFormatDateValid('2013-02-08 09:00:00-01:00'), true);
+  // t.is(isFormatDateValid('2013-02-08 09:00:00-0100'), true);
+
   t.is(isFormatDateValid('cat-1'), false);
   t.is(isFormatDateValid('2017-02-30'), false); 
   t.is(isFormatDateValid('2020-04-31'), false); 

--- a/src/lib/test/dataInference.spec.ts
+++ b/src/lib/test/dataInference.spec.ts
@@ -1,5 +1,7 @@
 import test from 'ava';
 import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+dayjs.extend(customParseFormat);
 import {
   autoInferenceType,
   detectValue,
@@ -68,23 +70,32 @@ test('isDateValid', t => {
 
   t.is(isFormatDateValid('1900-10-23'), true);
   t.is(isFormatDateValid('2002-5-5'), true);
-  t.is(isFormatDateValid('2008-09-31'), true);
   t.is(isFormatDateValid('1600-12-25'), true);
   t.is(isFormatDateValid('1942-11-1'), true);
   t.is(isFormatDateValid('2000-10-10'), true);
-  t.is(isFormatDateValid('2018-02-29'), true); // this day doesn't exist but we check only the date format
-  t.is(isFormatDateValid('2017-02-30'), true); // this day doesn't exist but we check only the date format
-  t.is(isFormatDateValid('2020-04-31'), true); // this day doesn't exist but we check only the date format
   t.is(isFormatDateValid('2019-01-15 13:12:29'), true);
+  t.is(isFormatDateValid(new Date().toISOString()), true);
+  t.is(isFormatDateValid('2020-05-13T08:24:45.701Z'), true);
+  t.is(isFormatDateValid('2020-05-01'), true);
+  t.is(isFormatDateValid('2020-05-1'), true);
+  t.is(isFormatDateValid('2020-5-01'), true);
+  t.is(isFormatDateValid('2020-5-1'), true);
+  t.is(isFormatDateValid('2020-05-01 00:00'), true);
+  t.is(isFormatDateValid('2020-05-01 00:00:00'), true);
+  t.is(isFormatDateValid('2020-05-01 00:00:00.101'), true);
+  t.is(isFormatDateValid('2016-01-01 11:31:23 AM'), true);
+  t.is(isFormatDateValid('2016-01-01 11:31:23 am'), true);
+  t.is(isFormatDateValid('2016-01-01 23:31:23 pm'), true);
   t.is(isFormatDateValid('17-02-2019', rightParser), true);
   t.is(isFormatDateValid('17-02-2019', wrongParser), true); // this shouldn't be right but we assume that if the user has written a parser, then the dates are in the correct format
   t.is(isFormatDateValid('17-02-2019', defaultParser), true); // this shouldn't be right but we assume that if the user has written a parser, then the dates are in the correct format
-  
   t.is(isFormatDateValid('2019-01-15 13:12:29'), true);
-  t.is(isFormatDateValid('2019-01-15 24:00:00'), false);
-  t.is(isFormatDateValid('2019-01-15 23:60:00'), false);
-  t.is(isFormatDateValid('2019-01-15 23:59:60'), false);
-  t.is(isFormatDateValid('2019-01-15 13:12:29.0'), false);
+  
+  t.is(isFormatDateValid('cat-1'), false);
+  t.is(isFormatDateValid('2017-02-30'), false); 
+  t.is(isFormatDateValid('2020-04-31'), false); 
+  t.is(isFormatDateValid('2018-02-29'), false); 
+  t.is(isFormatDateValid('2008-09-31'), false);
   t.is(isFormatDateValid('17-02-2019'), false);
   t.is(isFormatDateValid('0000-01-01'), false);
   t.is(isFormatDateValid('0100-10-23'), false);
@@ -92,7 +103,20 @@ test('isDateValid', t => {
   t.is(isFormatDateValid('1942-11-0'), false);
   t.is(isFormatDateValid('1942-00-25'), false);
   t.is(isFormatDateValid('2000-10-00'), false);
-  t.is(isFormatDateValid('cat-1'), false);
+  t.is(isFormatDateValid('2019-01-15 24:00:00'), false);
+  t.is(isFormatDateValid('2019-01-15 23:60:00'), false);
+  t.is(isFormatDateValid('2019-01-15 23:59:60'), false);
+  t.is(isFormatDateValid('2019-01-15 13:12:29.0'), false);
+  t.is(isFormatDateValid('2020-05-01 01:01:01.12'), false);
+  t.is(isFormatDateValid('2016-01-01 11:31:23 PM'), false);
+  t.is(isFormatDateValid('2020-05-01 00'), false);
+  t.is(isFormatDateValid('2020-02-31'), false);
+  t.is(isFormatDateValid('2016/01/01'), false);
+  t.is(isFormatDateValid('2020-05-01 01:60:00'), false);
+  t.is(isFormatDateValid('2020-05-01 60'), false);
+  t.is(isFormatDateValid('2020-05-01 '), false);
+  t.is(isFormatDateValid(new Date().toString()), false);
+  t.is(isFormatDateValid('Wed May 13 2020 10:25:23 GMT+0200 (Central European Summer Time)'), false);
 });
 
 // ----------------------------------------------------------

--- a/src/lib/test/dataInference.spec.ts
+++ b/src/lib/test/dataInference.spec.ts
@@ -75,10 +75,17 @@ test('isDateValid', t => {
   t.is(isFormatDateValid('2018-02-29'), true); // this day doesn't exist but we check only the date format
   t.is(isFormatDateValid('2017-02-30'), true); // this day doesn't exist but we check only the date format
   t.is(isFormatDateValid('2020-04-31'), true); // this day doesn't exist but we check only the date format
+  t.is(isFormatDateValid('2019-01-15 13:12:29'), true);
+  t.is(isFormatDateValid('2019-01-15, 13:12:29'), true);
+  t.is(isFormatDateValid('2019-01-15, 00:00:00'), true);
+  t.is(isFormatDateValid('2019-01-15, 23:59:59'), true);
   t.is(isFormatDateValid('17-02-2019', rightParser), true);
   t.is(isFormatDateValid('17-02-2019', wrongParser), true); // this shouldn't be right but we assume that if the user has written a parser, then the dates are in the correct format
   t.is(isFormatDateValid('17-02-2019', defaultParser), true); // this shouldn't be right but we assume that if the user has written a parser, then the dates are in the correct format
-
+  
+  t.is(isFormatDateValid('2019-01-15, 24:00:00'), false);
+  t.is(isFormatDateValid('2019-01-15, 23:60:00'), false);
+  t.is(isFormatDateValid('2019-01-15, 23:59:60'), false);
   t.is(isFormatDateValid('2019-01-15 13:12:29.0'), false);
   t.is(isFormatDateValid('17-02-2019'), false);
   t.is(isFormatDateValid('0000-01-01'), false);

--- a/src/lib/test/dataInference.spec.ts
+++ b/src/lib/test/dataInference.spec.ts
@@ -95,7 +95,6 @@ test('isDateValid', t => {
   t.is(isFormatDateValid('2016-01-01 11:31:23 am'), true);
   t.is(isFormatDateValid('2016-01-01 23:31:23 pm'), true);
 
-
   t.is(isFormatDateValid('17-02-2019', rightParser), true);
   t.is(isFormatDateValid('17-02-2019', wrongParser), true); // this shouldn't be right but we assume that if the user has written a parser, then the dates are in the correct format
   t.is(isFormatDateValid('17-02-2019', defaultParser), true); // this shouldn't be right but we assume that if the user has written a parser, then the dates are in the correct format

--- a/tslint.json
+++ b/tslint.json
@@ -25,12 +25,14 @@
     "no-class": true,
     "no-mixed-interface": false,
     "no-expression-statement": [
-      true,
+      false,
       { "ignore-prefix": ["console.", "process.exit"] }
     ],
     "no-if-statement": false,
     /* end tslint-immutable rules */
 
-    "ordered-imports": false
+    "ordered-imports": false,
+    "curly": false,
+    "no-shadowed-variable": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1603,9 +1603,9 @@ dateformat@^3.0.0:
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
 dayjs@^1.8.13:
-  version "1.8.13"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.13.tgz#51b5cdad23ba508bcea939a853b492fefb7fdc47"
-  integrity sha512-JZ01l/PMU8OqwuUs2mOQ/CTekMtoXOUSylfjqjgDzbhRSxpFIrPnHn8Y8a0lfocNgAdBNZb8y0/gbzJ2riQ4WQ==
+  version "1.8.27"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.27.tgz#a8ae63ee990af28c05c430f0e160ae835a0fbbf8"
+  integrity sha512-Jpa2acjWIeOkg8KURUHICk0EqnEFSSF5eMEscsOgyJ92ZukXwmpmRkPSUka7KHSfbj5eKH30ieosYip+ky9emQ==
 
 debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"


### PR DESCRIPTION
**Please check the type of change your PR introduces:**
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring / Code style update (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation
- [ ] Other (please describe): 

Related to [this issue](https://github.com/accurat/views/issues/358).
Data juggler supports now also time, not only dates.

[ref](https://day.js.org/docs/en/parse/string-format)
Formats we support:

- `YYYY-MM-DD`,
- `YYYY-MM-D`,
- `YYYY-M-DD`,
- `YYYY-M-D`,

- `YYYY-MM-DD HH:mm`,
- `YYYY-MM-DD HH:mm[Z]`,
- `YYYY-MM-DD[T]HH:mm`,
- `YYYY-MM-DD[T]HH:mm[Z]`,

- `YYYY-MM-DD HH:mm:ss`,
- `YYYY-MM-DD HH:mm:ss[Z]`,
- `YYYY-MM-DD[T]HH:mm:ss`,
- `YYYY-MM-DD[T]HH:mm:ss[Z]`,

- `YYYY-MM-DD HH:mm:ss.SSS`,
- `YYYY-MM-DD HH:mm:ss.SSS[Z]`,
- `YYYY-MM-DD[T]HH:mm:ss.SSS`,
- `YYYY-MM-DD[T]HH:mm:ss.SSS[Z]`, // ISO8601

- `YYYY-MM-DD HH:mm:ss A`,
- `YYYY-MM-DD HH:mm:ss a`,

In the future we would like to support also these two formats that for some strange reasons they actually don`t work:
- `YYYY-MM-DD HH:mm:ssZ`, ie. `2013-02-08 09:00:00+07:00`, `2013-02-08 09:00:00+07:30`
- `YYYY-MM-DD HH:mm:ssZZ`, ie `2013-02-08 09:00:00-0700`, `2013-02-08 09:00:00-0730`

Where:

| Format | Example | Description |
|--------|---------|-------------|
| YYYY | 2018 | Four-digit year |
| MM | 01-12 | Month, 2-digits |
| M | 1-12 | Month, beginning at 1 |
| DD | 01-31 | Day of month, 2-digits |
| D | 1-31 | Day of month |
| HH | 00-23 | Hours, 2-digits |
| mm | 00-59 | Minutes, 2-digits |
| ss | 00-59 | Seconds, 2-digits |
| SSS | 000-999 | Milliseconds, 3-digits |
| A | AM, PM | Post or ante meridiem, upper-case |
| a | am, pm | Post or ante meridiem, lower-case |

Examples:

✅ `1900-10-23`
✅ `1942-11-1`
✅ `2002-5-15`
✅ `2000-01-10`
✅ `2020-05-01 09:35`
✅ `2020-05-01 09:35Z`
✅ `2020-05-01T09:35`
✅ `2020-05-01T09:35Z`
✅ `2020-05-01 09:35:20`
✅ `2019-01-15 13:12:29`
✅ `2020-05-01 09:35:20Z`
✅ `2020-05-01T09:35:20`
✅ `2020-05-01T09:35:20Z`
✅ `2020-05-01 09:35:20.000`
✅ `2020-05-01 09:35:20.000Z`
✅ `2020-05-01T09:35:20.000`
✅ `2020-05-01T09:35:20.000Z`
✅ `2020-05-13T08:24:45.701Z`
✅ `2016-01-01 11:31:23 AM`
✅ `2016-01-01 11:31:23 am`
✅ `2016-01-01 23:31:23 pm`

❌ `cat-1`
❌ `2017-02-30`
❌ `2020-04-31`
❌ `2018-02-29`
❌ `2008-09-31`
❌ `17-02-2019`
❌ `0000-01-01`
❌ `0100-10-23`
❌ `2009-23-5`
❌ `1942-11-0`
❌ `1942-00-25`
❌ `2000-10-00`
❌ `2019-01-15 24:00:00`
❌ `2019-01-15 23:60:00`
❌ `2019-01-15 23:59:60`
❌ `2019-01-15 13:12:29.0`
❌ `2020-05-01 01:01:01.12`
❌ `2016-01-01 11:31:23 PM`
❌ `2020-05-01 00`
❌ `2020-02-31`
❌ `2016/01/01`
❌ `2020-05-01 01:60:00`
❌ `2020-05-01 60`
❌ `2020-05-01 `
❌ `Wed May 13 2020 10:25:23 GMT+0200 (Central European Summer Time)`

I had to add `watch-tsc` command because`watch` command doesn't work because of [this issue](https://github.com/accurat/data-juggler/issues/23).
Probably we need a refactor, there are a lot of scripts.

**Does this introduce a breaking change?**

- [ ] Yes
- [x] No
